### PR TITLE
fix: Added active_boot_type for alter_host

### DIFF
--- a/mfd_osd_control/mfd_osd_control.py
+++ b/mfd_osd_control/mfd_osd_control.py
@@ -241,6 +241,8 @@ class OsdController:
             params["refresh_mode"] = refresh.value
         if description:
             params["description"] = description
+        if active_boot_type is not None:
+            params["active_boot_type"] = active_boot_type.value
 
         logger.log(
             log_levels.MODULE_DEBUG,


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `alter_host` method in `mfd_osd_control.py`. The change adds support for setting the `active_boot_type` parameter when it is provided.

* [`mfd_osd_control/mfd_osd_control.py`](diffhunk://#diff-31b78073458b27c4107b06445243f6d4f7eb943a0c65bfd19bbeaea2d1158b62R244-R245): Added logic to include the `active_boot_type` parameter in the `params` dictionary if it is not `None`. (`[mfd_osd_control/mfd_osd_control.pyR244-R245](diffhunk://#diff-31b78073458b27c4107b06445243f6d4f7eb943a0c65bfd19bbeaea2d1158b62R244-R245)`)